### PR TITLE
Add injection of metric name into dynamic tag callback

### DIFF
--- a/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/DatadogReporter.java
+++ b/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/DatadogReporter.java
@@ -15,6 +15,7 @@ import com.viafoura.metrics.datadog.model.DatadogGauge;
 import com.viafoura.metrics.datadog.transport.HttpTransport;
 import com.viafoura.metrics.datadog.transport.Transport;
 import com.viafoura.metrics.datadog.transport.UdpTransport;
+import com.viafoura.metrics.datadog.TagUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,35 +78,32 @@ public class DatadogReporter extends ScheduledReporter {
                      SortedMap<String, Timer> timers) {
     final long timestamp = clock.getTime() / 1000;
 
-    List<String> newTags = tags;
-    if (tagsCallback != null) {
-      List<String> dynamicTags = tagsCallback.getTags();
-      if (dynamicTags != null && ! dynamicTags.isEmpty()) {
-        newTags = TagUtils.mergeTags(tags, dynamicTags);
-      }
-    }
-
     try {
       request = transport.prepare();
 
       for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-        reportGauge(prefix(entry.getKey()), entry.getValue(), timestamp, newTags);
+        String name = prefix(entry.getKey());
+        reportGauge(name, entry.getValue(), timestamp, TagUtils.createTagsWithMetricsName(name, tagsCallback, tags));
       }
 
       for (Map.Entry<String, Counter> entry : counters.entrySet()) {
-        reportCounter(prefix(entry.getKey()), entry.getValue(), timestamp, newTags);
+        String name = prefix(entry.getKey());
+        reportCounter(name, entry.getValue(), timestamp, TagUtils.createTagsWithMetricsName(name, tagsCallback, tags));
       }
 
       for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
-        reportHistogram(prefix(entry.getKey()), entry.getValue(), timestamp, newTags);
+        String name = prefix(entry.getKey());
+        reportHistogram(name, entry.getValue(), timestamp, TagUtils.createTagsWithMetricsName(name, tagsCallback, tags));
       }
 
       for (Map.Entry<String, Meter> entry : meters.entrySet()) {
-        reportMetered(prefix(entry.getKey()), entry.getValue(), timestamp, newTags);
+        String name = prefix(entry.getKey());
+        reportMetered(name, entry.getValue(), timestamp, TagUtils.createTagsWithMetricsName(name, tagsCallback, tags));
       }
 
       for (Map.Entry<String, Timer> entry : timers.entrySet()) {
-        reportTimer(prefix(entry.getKey()), entry.getValue(), timestamp, newTags);
+        String name = prefix(entry.getKey());
+        reportTimer(name, entry.getValue(), timestamp, TagUtils.createTagsWithMetricsName(name, tagsCallback, tags));
       }
 
       request.send();

--- a/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/DynamicTagsCallback.java
+++ b/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/DynamicTagsCallback.java
@@ -13,5 +13,5 @@ public interface DynamicTagsCallback {
    * @return dynamic tags that will merge into the static tags. Dynamic tags will overwrite
    * static tags with the same key
    */
-  public List<String> getTags();
+  public List<String> getTags(String metric);
 }

--- a/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/TagUtils.java
+++ b/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/TagUtils.java
@@ -50,4 +50,17 @@ class TagUtils {
 
     return newTags;
   }
+
+  public static List<String> createTagsWithMetricsName(String metricsName, DynamicTagsCallback tagsCallback, List<String> tags) {
+    List<String> newTags = tags;
+
+    if (tagsCallback != null) {
+      List<String> dynamicTags = tagsCallback.getTags(metricsName);
+      if (dynamicTags != null && ! dynamicTags.isEmpty()) {
+        newTags = TagUtils.mergeTags(tags, dynamicTags);
+      }
+    }
+
+    return newTags;
+  }
 }

--- a/metrics-datadog/src/test/java/com/viafoura/metrics/datadog/DatadogReporterTest.java
+++ b/metrics-datadog/src/test/java/com/viafoura/metrics/datadog/DatadogReporterTest.java
@@ -48,7 +48,6 @@ public class DatadogReporterTest {
   class MetricsTagger implements DynamicTagsCallback {
     @Override
     public List<String> getTags(String metric) {
-      System.out.println("GOT METRIC: " + metric);
       return new ArrayList<String>() {
         {
           add(String.format("metric:%s", metric));

--- a/metrics-datadog/src/test/java/com/viafoura/metrics/datadog/DatadogReporterTest.java
+++ b/metrics-datadog/src/test/java/com/viafoura/metrics/datadog/DatadogReporterTest.java
@@ -37,11 +37,25 @@ public class DatadogReporterTest {
   private final Transport.Request request =
       mock(Transport.Request.class);
   private final DynamicTagsCallback callback = mock(DynamicTagsCallback.class);
+  private final DynamicTagsCallback customCallback = new MetricsTagger();
   private MetricRegistry metricsRegistry;
   private DatadogReporter reporter;
   private DatadogReporter reporterWithPrefix;
   private DatadogReporter reporterWithCallback;
+  private DatadogReporter reporterWithCustomCallback;
   private List<String> tags;
+
+  class MetricsTagger implements DynamicTagsCallback {
+    @Override
+    public List<String> getTags(String metric) {
+      System.out.println("GOT METRIC: " + metric);
+      return new ArrayList<String>() {
+        {
+          add(String.format("metric:%s", metric));
+        }
+      };
+    }
+  }
 
   @Before
   public void setUp() throws IOException {
@@ -82,6 +96,15 @@ public class DatadogReporterTest {
         .withDynamicTagCallback(callback)
         .build();
 
+    reporterWithCustomCallback = DatadogReporter
+        .forRegistry(metricsRegistry)
+        .withHost(HOST)
+        .withClock(clock)
+        .convertRatesTo(TimeUnit.SECONDS)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .withTransport(transport)
+        .withDynamicTagCallback(customCallback)
+        .build();
   }
 
   @Test
@@ -365,7 +388,7 @@ public class DatadogReporterTest {
     dynamicTags.add("status:active");
     dynamicTags.add("speed:29");
 
-    when(callback.getTags()).thenReturn(dynamicTags);
+    when(callback.getTags("counter")).thenReturn(dynamicTags);
 
     final Counter counter = mock(Counter.class);
     when(counter.getCount()).thenReturn(100L);
@@ -377,6 +400,26 @@ public class DatadogReporterTest {
             this.<Timer>map());
 
     verify(request).addGauge(new DatadogGauge("counter", 100L, timestamp, HOST, dynamicTags));
+  }
+
+  @Test
+  public void reportsWithDynamicMetricCallback() throws Exception {
+    List<String> expectedTags = new ArrayList<String>() {
+      {
+        add("metric:counter");
+      }
+    };
+
+    final Counter counter = mock(Counter.class);
+    when(counter.getCount()).thenReturn(100L);
+
+    reporterWithCustomCallback.report(this.<Gauge>map(),
+            this.<Counter>map("counter", counter),
+            this.<Histogram>map(),
+            this.<Meter>map(),
+            this.<Timer>map());
+
+    verify(request).addGauge(new DatadogGauge("counter", 100L, timestamp, HOST, expectedTags));
   }
 
   @Test


### PR DESCRIPTION
Allows tagging of metrics with the name of the metric. 

Not 100% with this code-base yet - mostly iffy on grabbing the name of the metric correctly and passing into the DynamicTagCallback. Otherwise, it works and is proven by the passing tests.