### PR TITLE
Update metric submission endpoints

### DIFF
--- a/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/transport/HttpTransport.java
+++ b/metrics-datadog/src/main/java/com/viafoura/metrics/datadog/transport/HttpTransport.java
@@ -31,8 +31,8 @@ public class HttpTransport implements Transport {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpTransport.class);
 
-  private final static String BASE_URL_US = "https://app.datadoghq.com/api/v1";
-  private final static String BASE_URL_EU = "https://app.datadoghq.eu/api/v1";
+  private final static String BASE_URL_US = "https://api.datadoghq.com/api/v1";
+  private final static String BASE_URL_EU = "https://api.datadoghq.eu/api/v1";
   private final String seriesUrl;
   private final int connectTimeout;     // in milliseconds
   private final int socketTimeout;      // in milliseconds


### PR DESCRIPTION
api.datadoghq.com is Datadog's preferred submission end point for metrics. app.datadoghq.com will continue to work but does not offer a number of newer capabilities.