### PR TITLE
Update java-dogstatsd-client to latest version. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>2.8</version>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
We have had some vulnerability alerts come up that we traced down to the version of ` java-dogstatsd-client` being used here. 
Changes:
- Updated ` java-dogstatsd-client` version to `4.0.0`
- Updated code to make it compliant with new version of java-dogstatsd-client.

