### PR TITLE
Update Datadog client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,12 @@
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>4.0.0</version>
+                <version>4.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-unixsocket</artifactId>
+                <version>0.38.19</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
We have had some vulnerability alerts come up that we traced down to the version of  `jnr-unixsocket` through `java-dogstatsd-client` being used here.

Changes:
- Updated  `java-dogstatsd-client` version to 4.1.0
- Updated `jnr-unixsocket` dependency to latest version (Reference: https://github.com/DataDog/java-dogstatsd-client/blob/master/DEPS.md#java-8)